### PR TITLE
#161976500 add user input validations 

### DIFF
--- a/app/api/version1/tests/test_order_endpoints.py
+++ b/app/api/version1/tests/test_order_endpoints.py
@@ -43,6 +43,26 @@ class ParcelOrderEndpointsTests(unittest.TestCase):
                 "status": NOT_DELIVERED}}
         self.assertEqual(response.get_json(), expected_json)
 
+    def test_post_new_parcel_validation_with_defective_data(self):
+        defective_data = {
+            "user_id": "my id is 1",
+            "sender": "bob",
+            "recipient": "linda",
+            "pickup": "home",
+            "destination": "restaurant",
+            "weight": 2
+        }
+        response = self.app.post('/api/v1/parcels',
+                                 data=json.dumps(defective_data),
+                                 content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+        expected_json = {
+            "message": {
+                "user_id": "Order must have an integer user id"
+            }
+        }
+        self.assertEqual(response.get_json(), expected_json)
+
     def test_get_all_parcel_delivery_orders(self):
         self.app.post('/api/v1/parcels',
                       data=json.dumps(self.data),

--- a/app/api/version1/views.py
+++ b/app/api/version1/views.py
@@ -1,7 +1,7 @@
 # views.py
 
 from flask import jsonify, make_response, request
-from flask_restful import Resource
+from flask_restful import fields, marshal_with, reqparse, Resource
 
 from .models import CANCELLED
 from .models import ParcelOrderStore
@@ -13,13 +13,28 @@ class ParcelOrderList(Resource, ParcelOrderStore):
         self.store = ParcelOrderStore()
 
     def post(self):
-        request_data = request.get_json()
-        user_id = request_data["user_id"]
-        sender = request_data["sender"]
-        recipient = request_data["recipient"]
-        pickup = request_data["pickup"]
-        destination = request_data["destination"]
-        weight = request_data["weight"]
+        parser = reqparse.RequestParser()
+        parser.add_argument('user_id', type=int, required=True,
+                            help="Order must have an integer user id")
+        parser.add_argument('sender', type=str, required=True,
+                            help="Order must have a sender")
+        parser.add_argument('recipient', type=str, required=True,
+                            help="Order must have a recipient")
+        parser.add_argument('pickup', type=str, required=True,
+                            help="Order must have a pickup")
+        parser.add_argument('destination', type=str, required=True,
+                            help="Order must have a destination")
+        parser.add_argument('weight', type=str, required=True,
+                            help="Order must have a weight")
+
+        args = parser.parse_args()
+
+        user_id = args["user_id"]
+        sender = args["sender"]
+        recipient = args["recipient"]
+        pickup = args["pickup"]
+        destination = args["destination"]
+        weight = args["weight"]
 
         parcel_order = self.store.save(user_id, sender, recipient, pickup,
                                        destination, weight)
@@ -63,8 +78,11 @@ class ParcelOrderCancellation(Resource, ParcelOrderStore):
         self.store = ParcelOrderStore()
 
     def put(self, order_id):
-        request_data = request.get_json()
-        status = request_data["status"]
+        parser = reqparse.RequestParser()
+        parser.add_argument('status', type=str, required=True,
+                            help="You must have a status")
+        args = parser.parse_args()
+        status = args["status"]
         try:
             if status == CANCELLED:
                 order = self.store.cancel_by_id(order_id)


### PR DESCRIPTION
#### What does this PR do?
it adds validations for all user inputs via `POST` and `PUT` requests
#### How should this be manually tested?
* Clone this repo `git clone -b ch-add-field-validation-161976500 https://github.com/cob04/Send-It.git`
view the `README.md` file
* Create a new virtual environment and run `pip install -r requirements.txt` from the root directory,
from the same directory run `python run.py`
* Using a `HTTP` client e.g. Postman, navigate to the endpoints `POST` `http://localhost:5000/api/v1/parcels` 
and `PUT` `http://localhost:5000:/api/v1/<user_id>/cancel` and try passing valid and invalid data.
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/161976500](https://www.pivotaltracker.com/story/show/161976500)